### PR TITLE
small bugfix for calories input

### DIFF
--- a/src/main/java/seedu/lifetrack/system/storage/CaloriesFileHandler.java
+++ b/src/main/java/seedu/lifetrack/system/storage/CaloriesFileHandler.java
@@ -78,7 +78,7 @@ public class CaloriesFileHandler extends FileHandler {
             throw new FileHandlerException(getFileInvalidEntryTypeMessage(lineNumber, filePath));
         }
         
-        if (entryType.equals("C_IN") && dataLength != 8) {
+        if (entryType.equals("C_IN") && dataLength != 8 && dataLength != 5) {
             throw new FileHandlerException(getFileTooFewMacrosMessage(lineNumber, filePath));
         } else if (entryType.equals("C_OUT") && dataLength != 5) {
             throw new FileHandlerException(getFileMacrosInOutputMessage(lineNumber, filePath));


### PR DESCRIPTION
very small bugfix where "C_IN" entry type forces the calories file handler to look for data length of 8 only, even though data length of 5 can still exist where the user did not input macronutrients